### PR TITLE
Add disposing check

### DIFF
--- a/CameraExtensions.cs
+++ b/CameraExtensions.cs
@@ -79,9 +79,12 @@ namespace ApxLabs.FastAndroidCamera
 
 		protected override void Dispose(bool disposing)
 		{
-			if (class_ref != IntPtr.Zero)
-				JNIEnv.DeleteGlobalRef(class_ref);
-			class_ref = IntPtr.Zero;
+			if (disposing) {
+				if (class_ref != IntPtr.Zero) {
+					JNIEnv.DeleteGlobalRef(class_ref);
+				}
+				class_ref = IntPtr.Zero;
+			}
 			base.Dispose(disposing);
 		}
 

--- a/FastJavaByteArray.cs
+++ b/FastJavaByteArray.cs
@@ -87,8 +87,10 @@ namespace ApxLabs.FastAndroidCamera
 		{
 			unsafe
 			{
-				// tell Java that we're done with this array
-				JniEnvEx.ReleaseByteArrayElements(Handle, Raw, IsReadOnly ? PrimitiveArrayReleaseMode.Release : PrimitiveArrayReleaseMode.CommitAndRelease);
+				if (disposing) {
+					// tell Java that we're done with this array
+					JniEnvEx.ReleaseByteArrayElements(Handle, Raw, IsReadOnly ? PrimitiveArrayReleaseMode.Release : PrimitiveArrayReleaseMode.CommitAndRelease);
+				}
 			}
 			base.Dispose(disposing);
 		}


### PR DESCRIPTION
According to the [disposing pattern](https://msdn.microsoft.com/en-us/library/b1yfkh5e%28v=vs.110%29.aspx) one should check the disposing flag.

This also fixes the `JNI DETECTED ERROR IN APPLICATION: jarray was NULL` error
